### PR TITLE
Allow swapping default servers order

### DIFF
--- a/src/main/java/glowredman/defaultserverlist/Config.java
+++ b/src/main/java/glowredman/defaultserverlist/Config.java
@@ -49,7 +49,7 @@ public class Config {
                                 private static final long serialVersionUID = -1786059589535074931L;
                             }.getType());
 
-                    if (config.allowDeletions) {
+                    if (config.allowModifications) {
                         // servers that were added to the remote location since the last time the list was fetched
                         Map<String, String> diff = new LinkedHashMap<>();
 
@@ -99,7 +99,7 @@ public class Config {
     public static final class ConfigObj {
 
         public boolean useURL = false;
-        public boolean allowDeletions = true;
+        public boolean allowModifications = true;
         public String url = "";
         public Map<String, String> servers = new LinkedHashMap<>();
 


### PR DESCRIPTION
You can now swap the order of default servers by pressing shift + ↑ or shift + ↓ in the multiplayer menu if **allowModifications** (which is previously named **allowDeletions**) config is true
The order persists across reboots but not after config update

https://user-images.githubusercontent.com/39122497/186875729-f7c71b50-d58d-480c-9f28-d1071969565f.mp4