### PR TITLE
Use Forge configs instead of JSON

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -50,10 +50,10 @@ enableGenericInjection = true
 # Generate a class with a String field for the mod version named as defined below.
 # If generateGradleTokenClass is empty or not missing, no such class will be generated.
 # If gradleTokenVersion is empty or missing, the field will not be present in the class.
-generateGradleTokenClass =
+generateGradleTokenClass = glowredman.defaultserverlist.Tags
 
 # Name of the token containing the project's current version to generate/replace.
-gradleTokenVersion =
+gradleTokenVersion = VERSION
 
 # [DEPRECATED] Mod ID replacement token.
 gradleTokenModId =
@@ -106,7 +106,7 @@ coreModClass = LoadingPlugin
 
 # If your project is only a consolidation of mixins or a core mod and does NOT contain a 'normal' mod ( = some class
 # that is annotated with @Mod) you want this to be true. When in doubt: leave it on false!
-containsMixinsAndOrCoreModOnly = false
+containsMixinsAndOrCoreModOnly = true
 
 # Enables Mixins even if this mod doesn't use them, useful if one of the dependencies uses mixins.
 forceEnableMixins = false

--- a/src/main/java/glowredman/defaultserverlist/LoadingPlugin.java
+++ b/src/main/java/glowredman/defaultserverlist/LoadingPlugin.java
@@ -19,11 +19,13 @@ import cpw.mods.fml.relauncher.IFMLLoadingPlugin.TransformerExclusions;
 import cpw.mods.fml.relauncher.Side;
 
 @MCVersion("1.7.10")
-@Name("DefaultServerList")
+@Name("DefaultServerList Core")
 @TransformerExclusions("glowredman.defaultserverlist.LoadingPlugin")
 public class LoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader {
 
     public static final Logger LOGGER = LogManager.getLogger("DefaultServerList");
+
+    static File location;
 
     @Override
     public String getMixinConfig() {
@@ -45,6 +47,9 @@ public class LoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader {
 
     @Override
     public String getModContainerClass() {
+        if (FMLLaunchHandler.side() == Side.CLIENT) {
+            return ModContainer.class.getName();
+        }
         return null;
     }
 
@@ -55,8 +60,9 @@ public class LoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader {
 
     @Override
     public void injectData(Map<String, Object> data) {
-        if (FMLLaunchHandler.side() == Side.CLIENT) {
-            Config.init(new File((File) data.get("mcLocation"), "config"));
+        location = (File) data.get("coremodLocation");
+        if (location == null) {
+            location = new File(this.getClass().getProtectionDomain().getCodeSource().getLocation().getPath());
         }
     }
 

--- a/src/main/java/glowredman/defaultserverlist/LoadingPlugin.java
+++ b/src/main/java/glowredman/defaultserverlist/LoadingPlugin.java
@@ -6,6 +6,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import com.gtnewhorizon.gtnhmixins.IEarlyMixinLoader;
 
 import cpw.mods.fml.relauncher.FMLLaunchHandler;
@@ -19,6 +22,8 @@ import cpw.mods.fml.relauncher.Side;
 @Name("DefaultServerList")
 @TransformerExclusions("glowredman.defaultserverlist.LoadingPlugin")
 public class LoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader {
+
+    public static final Logger LOGGER = LogManager.getLogger("DefaultServerList");
 
     @Override
     public String getMixinConfig() {
@@ -51,7 +56,7 @@ public class LoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader {
     @Override
     public void injectData(Map<String, Object> data) {
         if (FMLLaunchHandler.side() == Side.CLIENT) {
-            Config.preInit(new File((File) data.get("mcLocation"), "config"));
+            Config.init(new File((File) data.get("mcLocation"), "config"));
         }
     }
 

--- a/src/main/java/glowredman/defaultserverlist/ModContainer.java
+++ b/src/main/java/glowredman/defaultserverlist/ModContainer.java
@@ -1,0 +1,59 @@
+package glowredman.defaultserverlist;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Set;
+
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+
+import cpw.mods.fml.common.DummyModContainer;
+import cpw.mods.fml.common.LoadController;
+import cpw.mods.fml.common.ModMetadata;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import cpw.mods.fml.common.versioning.ArtifactVersion;
+import cpw.mods.fml.common.versioning.VersionParser;
+import cpw.mods.fml.common.versioning.VersionRange;
+
+public class ModContainer extends DummyModContainer {
+
+    public ModContainer() {
+        super(new ModMetadata());
+        ModMetadata md = this.getMetadata();
+
+        // NOTE: If you change this, change mcmod.info too!
+        md.authorList = Collections.singletonList("glowredman");
+        md.description = "Add default servers to the multiplayer screen.";
+        md.modId = "defaultserverlist";
+        md.name = "DefaultServerList";
+        md.updateUrl = "https://files.data-hole.de/mods/defaultserverlist/updates.json";
+        md.url = "https://github.com/glowredman/DefaultServerList";
+        md.version = Tags.VERSION;
+    }
+
+    @Override
+    public VersionRange acceptableMinecraftVersionRange() {
+        return VersionParser.parseRange("[1.7.10]");
+    }
+
+    @Override
+    public Set<ArtifactVersion> getRequirements() {
+        return Collections.singleton(VersionParser.parseVersionReference("gtnhmixins"));
+    }
+
+    @Override
+    public File getSource() {
+        return LoadingPlugin.location;
+    }
+
+    @Override
+    public boolean registerBus(EventBus bus, LoadController controller) {
+        bus.register(this);
+        return true;
+    }
+
+    @Subscribe
+    public void preInit(FMLPreInitializationEvent event) {
+        Config.init(event.getModConfigurationDirectory());
+    }
+}

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,5 +1,6 @@
 [
     {
+      "__comment": "NOTE: If you change this, change ModContainer.java too!",
       "modid": "${modId}",
       "name": "${modName}",
       "description": "Add default servers to the multiplayer screen.",


### PR DESCRIPTION
**Motivation:**
Currently, JSON configs are used. While this makes it easy to represent `Map`s, it is not possible to backup the `servers` map using the Default Configs mod. By switching to Forge's config system, this becomes possible. Existing configs are converted automatically.